### PR TITLE
feat: add persistent dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Host your digital comics (CBZ/CBR/CB7/PDF files) on your home server and read th
 - 🖼️ **Thumbnail previews** – See cover images before opening
 - 📱 **Read anywhere** – Use your favorite comic reader app (Panels, Chunky, etc.)
 - 🌐 **Web reader** – Read in your browser without installing anything (on mobile too!)
+- 🌙 **Light and dark themes** – Follow your system preference or switch manually
 - 🔖 **Ongoing series** – Mark active series and quickly see new issues, totals, and possible gaps
 - ⚡ **Easy setup** – One command to get started
 

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -383,3 +383,137 @@
 .folder-preview-single .folder-thumb-4 {
   display: none;
 }
+
+/* --- Color theme --- */
+html[data-theme="dark"] {
+  color-scheme: dark;
+}
+
+.theme-sun {
+  display: none;
+}
+
+html[data-theme="dark"] .theme-moon {
+  display: none;
+}
+
+html[data-theme="dark"] .theme-sun {
+  display: block;
+}
+
+html[data-theme="dark"] body {
+  background: linear-gradient(135deg, #111827 0%, #0f172a 48%, #1e1b4b 100%);
+  color: #e5e7eb;
+}
+
+html[data-theme="dark"] header {
+  background-color: rgb(17 24 39 / 0.88) !important;
+  border-color: #312e81 !important;
+}
+
+html[data-theme="dark"] .bg-white {
+  background-color: #1f2937 !important;
+}
+
+html[data-theme="dark"] .bg-white\/80,
+html[data-theme="dark"] .bg-white\/90 {
+  background-color: rgb(31 41 55 / 0.9) !important;
+}
+
+html[data-theme="dark"] .bg-gray-50,
+html[data-theme="dark"] .bg-gray-100,
+html[data-theme="dark"] .bg-violet-50 {
+  background-color: #111827 !important;
+}
+
+html[data-theme="dark"] .bg-violet-100 {
+  background-color: #312e81 !important;
+}
+
+html[data-theme="dark"] .text-gray-900,
+html[data-theme="dark"] .text-gray-800,
+html[data-theme="dark"] .text-gray-700 {
+  color: #f3f4f6 !important;
+}
+
+html[data-theme="dark"] .text-gray-600,
+html[data-theme="dark"] .text-gray-500 {
+  color: #d1d5db !important;
+}
+
+html[data-theme="dark"] .text-gray-400,
+html[data-theme="dark"] .text-gray-300 {
+  color: #9ca3af !important;
+}
+
+html[data-theme="dark"] .text-violet-600,
+html[data-theme="dark"] .text-violet-700 {
+  color: #c4b5fd !important;
+}
+
+html[data-theme="dark"] .border-gray-100,
+html[data-theme="dark"] .border-gray-200,
+html[data-theme="dark"] .border-violet-100,
+html[data-theme="dark"] .border-violet-200 {
+  border-color: #4b5563 !important;
+}
+
+html[data-theme="dark"] input,
+html[data-theme="dark"] select,
+html[data-theme="dark"] textarea {
+  background-color: #111827 !important;
+  border-color: #4b5563 !important;
+  color: #f9fafb !important;
+}
+
+html[data-theme="dark"] input::placeholder,
+html[data-theme="dark"] textarea::placeholder {
+  color: #9ca3af;
+}
+
+html[data-theme="dark"] .hover\:bg-violet-50:hover,
+html[data-theme="dark"] .hover\:bg-violet-50\/60:hover,
+html[data-theme="dark"] .hover\:bg-violet-100:hover,
+html[data-theme="dark"] .hover\:bg-gray-50:hover {
+  background-color: #374151 !important;
+}
+
+html[data-theme="dark"] .hover\:bg-white:hover {
+  background-color: #4b5563 !important;
+}
+
+html[data-theme="dark"] .hover\:text-violet-600:hover,
+html[data-theme="dark"] .hover\:text-violet-700:hover,
+html[data-theme="dark"] .hover\:text-violet-800:hover,
+html[data-theme="dark"] .hover\:text-violet-900:hover {
+  color: #ddd6fe !important;
+}
+
+html[data-theme="dark"] .folder-thumb {
+  background-color: #111827;
+}
+
+html[data-theme="dark"] .skeleton {
+  background: linear-gradient(90deg, #1f2937 25%, #374151 50%, #1f2937 75%);
+  background-size: 200% 100%;
+}
+
+html[data-theme="dark"] .swal2-popup {
+  background-color: #1f2937;
+  color: #f3f4f6;
+}
+
+html[data-theme="dark"] .swal2-title,
+html[data-theme="dark"] .swal2-html-container {
+  color: #f3f4f6;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  body,
+  header,
+  .bg-white,
+  .bg-white\/80,
+  .bg-white\/90 {
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  }
+}

--- a/reader/static/js/theme.js
+++ b/reader/static/js/theme.js
@@ -1,0 +1,41 @@
+(() => {
+  const storageKey = 'issued-theme';
+  const root = document.documentElement;
+  const toggle = document.getElementById('theme-toggle');
+  const themeColor = document.querySelector('meta[name="theme-color"]');
+  const colorScheme = window.matchMedia('(prefers-color-scheme: dark)');
+
+  if (!toggle) return;
+
+  const applyTheme = (theme, persist = false) => {
+    const isDark = theme === 'dark';
+    root.dataset.theme = isDark ? 'dark' : 'light';
+    toggle.setAttribute('aria-pressed', String(isDark));
+    toggle.setAttribute('aria-label', `Switch to ${isDark ? 'light' : 'dark'} mode`);
+    toggle.title = toggle.getAttribute('aria-label');
+    themeColor?.setAttribute('content', isDark ? '#111827' : '#7c3aed');
+
+    if (persist) {
+      try {
+        localStorage.setItem(storageKey, root.dataset.theme);
+      } catch (_) {
+        // The selected theme still applies when storage is unavailable.
+      }
+    }
+  };
+
+  applyTheme(root.dataset.theme === 'dark' ? 'dark' : 'light');
+
+  toggle.addEventListener('click', () => {
+    applyTheme(root.dataset.theme === 'dark' ? 'light' : 'dark', true);
+  });
+
+  colorScheme.addEventListener('change', (event) => {
+    try {
+      if (localStorage.getItem(storageKey)) return;
+    } catch (_) {
+      // Follow the system setting when storage is unavailable.
+    }
+    applyTheme(event.matches ? 'dark' : 'light');
+  });
+})();

--- a/reader/templates/base.html
+++ b/reader/templates/base.html
@@ -8,6 +8,17 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="default">
   <title>{% block title %}Comic Library{% endblock %}</title>
+  <script>
+    (() => {
+      try {
+        const savedTheme = localStorage.getItem('issued-theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.dataset.theme = savedTheme || (prefersDark ? 'dark' : 'light');
+      } catch (_) {
+        document.documentElement.dataset.theme = 'light';
+      }
+    })();
+  </script>
   <script src="{{ url_path(request, 'reader_static', path='/js/tailwind.js') }}"></script>
   <script src="{{ url_path(request, 'reader_static', path='/js/htmx.min.js') }}"></script>
   <script src="{{ url_path(request, 'reader_static', path='/js/sweetalert2.all.min.js') }}"></script>
@@ -63,6 +74,12 @@
             class="flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-xl border border-violet-200 bg-white text-gray-600 shadow-sm transition hover:bg-violet-50 hover:text-violet-700 disabled:cursor-not-allowed disabled:opacity-60 touch-manipulation">
             <i data-lucide="refresh-cw" class="h-4 w-4"></i>
           </button>
+          <button type="button" id="theme-toggle" title="Switch to dark mode" aria-label="Switch to dark mode"
+            aria-pressed="false"
+            class="flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-xl border border-violet-200 bg-white text-gray-600 shadow-sm transition hover:bg-violet-50 hover:text-violet-700 touch-manipulation">
+            <i data-lucide="moon" class="theme-moon h-4 w-4"></i>
+            <i data-lucide="sun" class="theme-sun h-4 w-4"></i>
+          </button>
         </nav>
       </div>
       {% if breadcrumbs %}
@@ -89,6 +106,7 @@
     {% block content %}{% endblock %}
   </main>
   {% block scripts %}{% endblock %}
+  <script src="{{ url_path(request, 'reader_static', path='/js/theme.js') }}"></script>
   <script>lucide.createIcons();</script>
 </body>
 

--- a/tests/test_reader_scan_action.py
+++ b/tests/test_reader_scan_action.py
@@ -83,6 +83,9 @@ def test_reader_root_renders_scan_button(tmp_path, monkeypatch):
 
     assert response.status_code == 200
     assert 'id="scan-library-btn"' in response.text
+    assert 'id="theme-toggle"' in response.text
+    assert 'aria-label="Switch to dark mode"' in response.text
+    assert '/reader/static/js/theme.js' in response.text
 
 
 def test_reader_recent_renders_scan_button(tmp_path, monkeypatch):

--- a/tests/test_reader_theme.py
+++ b/tests/test_reader_theme.py
@@ -1,0 +1,20 @@
+"""Tests for the reader color theme controls."""
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_theme_script_supports_persistence_and_system_preference():
+    script = (PROJECT_ROOT / "reader/static/js/theme.js").read_text()
+
+    assert "issued-theme" in script
+    assert "prefers-color-scheme: dark" in script
+    assert "aria-pressed" in script
+
+
+def test_dark_theme_styles_are_scoped():
+    stylesheet = (PROJECT_ROOT / "reader/static/css/style.css").read_text()
+
+    assert 'html[data-theme="dark"]' in stylesheet


### PR DESCRIPTION
Adds an accessible light/dark mode toggle to the web reader navigation. It follows the system color preference on first visit and persists manual selections in localStorage. The change also updates the browser theme color, applies scoped dark styles across reader surfaces, documents the feature, and adds regression tests.

Testing: `node --check reader/static/js/theme.js` and the full `pytest` suite (68 passed).