### PR TITLE
feat: add thumbnails to OPDS navigation entries

### DIFF
--- a/server/opds/feeds.py
+++ b/server/opds/feeds.py
@@ -31,6 +31,34 @@ def _comic_thumb_href(comic_uuid: str) -> str:
     return f"/opds/comic/{comic_uuid}/thumbnail"
 
 
+def _folder_entry_xml(
+    folder_id: int,
+    title: str,
+    updated_ts: str,
+    base_url: str,
+    *,
+    thumbnail_uuid: Optional[str] = None,
+) -> str:
+    """Build a navigation entry with optional artwork for capable OPDS clients."""
+    thumbnail_link = ""
+    if thumbnail_uuid:
+        thumbnail_link = (
+            '\n    <link rel="http://opds-spec.org/image/thumbnail"'
+            f' href="{_absolute_href(base_url, _comic_thumb_href(thumbnail_uuid))}"'
+            ' type="image/webp" />'
+        )
+
+    return f"""
+  <entry>
+    <title>{_escape_xml(title)}</title>
+    <id>urn:folder:{folder_id}</id>
+    <updated>{updated_ts}</updated>{thumbnail_link}
+    <link rel="subsection"
+          href="{_absolute_href(base_url, _folder_href(folder_id))}"
+          type="application/atom+xml;profile=opds-catalog" />
+  </entry>"""
+
+
 def _recent_href(limit: int) -> str:
     return f"/opds/recent?limit={limit}"
 

--- a/server/opds/feeds.py
+++ b/server/opds/feeds.py
@@ -31,9 +31,10 @@ def _comic_thumb_href(comic_uuid: str) -> str:
     return f"/opds/comic/{comic_uuid}/thumbnail"
 
 
-def _folder_entry_xml(
-    folder_id: int,
+def _navigation_entry_xml(
+    entry_id: str,
     title: str,
+    target_path: str,
     updated_ts: str,
     base_url: str,
     *,
@@ -51,12 +52,30 @@ def _folder_entry_xml(
     return f"""
   <entry>
     <title>{_escape_xml(title)}</title>
-    <id>urn:folder:{folder_id}</id>
+    <id>{_escape_xml(entry_id)}</id>
     <updated>{updated_ts}</updated>{thumbnail_link}
     <link rel="subsection"
-          href="{_absolute_href(base_url, _folder_href(folder_id))}"
+          href="{_absolute_href(base_url, target_path)}"
           type="application/atom+xml;profile=opds-catalog" />
   </entry>"""
+
+
+def _folder_entry_xml(
+    folder_id: int,
+    title: str,
+    updated_ts: str,
+    base_url: str,
+    *,
+    thumbnail_uuid: Optional[str] = None,
+) -> str:
+    return _navigation_entry_xml(
+        f"urn:folder:{folder_id}",
+        title,
+        _folder_href(folder_id),
+        updated_ts,
+        base_url,
+        thumbnail_uuid=thumbnail_uuid,
+    )
 
 
 def _recent_href(limit: int) -> str:

--- a/server/opds/routes.py
+++ b/server/opds/routes.py
@@ -16,6 +16,7 @@ from .feeds import (
     _folder_entry_xml,
     _folder_href,
     _get_library_title,
+    _navigation_entry_xml,
     _now_iso,
     _recent_href,
     _root_href,
@@ -46,6 +47,20 @@ def _folder_preview_uuid(conn, folder_id: int) -> str | None:
         LIMIT 1
         """,
         (folder_id,),
+    )
+    row = cur.fetchone()
+    return row["uuid"] if row else None
+
+
+def _recent_preview_uuid(conn) -> str | None:
+    """Return the cover used by the first item in the Recent feed."""
+    cur = conn.execute(
+        """
+        SELECT uuid
+        FROM comics
+        ORDER BY last_scanned_at DESC, id DESC
+        LIMIT 1
+        """
     )
     row = cur.fetchone()
     return row["uuid"] if row else None
@@ -84,6 +99,7 @@ def opds_root(request: Request) -> Response:
             folder["id"]: _folder_preview_uuid(conn, folder["id"])
             for folder in folders
         }
+        recent_preview = _recent_preview_uuid(conn)
 
     updated = _now_iso()
     base_url = str(request.base_url)
@@ -103,15 +119,14 @@ def opds_root(request: Request) -> Response:
         )
 
     entries.append(
-        f"""
-  <entry>
-    <title>Recent</title>
-    <id>urn:recent</id>
-    <updated>{updated}</updated>
-    <link rel="subsection"
-          href="{_absolute_href(base_url, _recent_href(50))}"
-          type="application/atom+xml;profile=opds-catalog" />
-  </entry>"""
+        _navigation_entry_xml(
+            "urn:recent",
+            "Recent",
+            _recent_href(50),
+            updated,
+            base_url,
+            thumbnail_uuid=recent_preview,
+        )
     )
 
     xml = (

--- a/server/opds/routes.py
+++ b/server/opds/routes.py
@@ -29,27 +29,40 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-def _folder_preview_uuid(conn, folder_id: int) -> str | None:
-    """Return the newest comic cover available in a folder's full subtree."""
+def _folder_preview_uuids(conn, folder_ids: list[int]) -> dict[int, str]:
+    """Return the newest generated cover for each requested folder subtree."""
+    if not folder_ids:
+        return {}
+
+    placeholders = ",".join("?" for _ in folder_ids)
     cur = conn.execute(
-        """
-        WITH RECURSIVE folder_tree(id) AS (
-            SELECT id FROM folders WHERE id = ?
+        f"""
+        WITH RECURSIVE folder_tree(root_id, id) AS (
+            SELECT id, id FROM folders WHERE id IN ({placeholders})
             UNION ALL
-            SELECT f.id
+            SELECT ft.root_id, f.id
             FROM folders f
             INNER JOIN folder_tree ft ON f.parent_id = ft.id
+        ),
+        ranked_previews AS (
+            SELECT
+                ft.root_id,
+                c.uuid,
+                ROW_NUMBER() OVER (
+                    PARTITION BY ft.root_id
+                    ORDER BY COALESCE(c.last_scanned_at, c.created_at) DESC, c.id DESC
+                ) AS preview_rank
+            FROM comics c
+            INNER JOIN folder_tree ft ON c.folder_id = ft.id
+            WHERE c.thumbnail_generated = 1
         )
-        SELECT c.uuid
-        FROM comics c
-        INNER JOIN folder_tree ft ON c.folder_id = ft.id
-        ORDER BY COALESCE(c.last_scanned_at, c.created_at) DESC, c.id DESC
-        LIMIT 1
+        SELECT root_id, uuid
+        FROM ranked_previews
+        WHERE preview_rank = 1
         """,
-        (folder_id,),
+        folder_ids,
     )
-    row = cur.fetchone()
-    return row["uuid"] if row else None
+    return {row["root_id"]: row["uuid"] for row in cur.fetchall()}
 
 
 def _recent_preview_uuid(conn) -> str | None:
@@ -58,6 +71,7 @@ def _recent_preview_uuid(conn) -> str | None:
         """
         SELECT uuid
         FROM comics
+        WHERE thumbnail_generated = 1
         ORDER BY last_scanned_at DESC, id DESC
         LIMIT 1
         """
@@ -95,10 +109,10 @@ def opds_root(request: Request) -> Response:
             "SELECT id, name FROM folders WHERE parent_id IS NULL ORDER BY name"
         )
         folders = cur.fetchall()
-        folder_previews = {
-            folder["id"]: _folder_preview_uuid(conn, folder["id"])
-            for folder in folders
-        }
+        folder_previews = _folder_preview_uuids(
+            conn,
+            [folder["id"] for folder in folders],
+        )
         recent_preview = _recent_preview_uuid(conn)
 
     updated = _now_iso()
@@ -114,7 +128,7 @@ def opds_root(request: Request) -> Response:
                 folder["name"],
                 updated,
                 base_url,
-                thumbnail_uuid=folder_previews[folder["id"]],
+                thumbnail_uuid=folder_previews.get(folder["id"]),
             )
         )
 
@@ -170,10 +184,10 @@ def opds_folder(folder_id: int, request: Request) -> Response:
             (folder_id,),
         )
         comics = cur.fetchall()
-        subfolder_previews = {
-            subfolder["id"]: _folder_preview_uuid(conn, subfolder["id"])
-            for subfolder in subfolders
-        }
+        subfolder_previews = _folder_preview_uuids(
+            conn,
+            [subfolder["id"] for subfolder in subfolders],
+        )
 
     updated = _now_iso()
     base_url = str(request.base_url)
@@ -187,7 +201,7 @@ def opds_folder(folder_id: int, request: Request) -> Response:
                 sub["name"],
                 updated,
                 base_url,
-                thumbnail_uuid=subfolder_previews[sub["id"]],
+                thumbnail_uuid=subfolder_previews.get(sub["id"]),
             )
         )
 
@@ -237,7 +251,7 @@ def opds_recent(request: Request, limit: int = Query(50, ge=1, le=200)) -> Respo
             "FROM comics c "
             "JOIN folders f ON c.folder_id = f.id "
             "LEFT JOIN metadata m ON m.comic_id = c.id "
-            "ORDER BY c.last_scanned_at DESC LIMIT ?",
+            "ORDER BY c.last_scanned_at DESC, c.id DESC LIMIT ?",
             (limit,),
         )
         comics = cur.fetchall()

--- a/server/opds/routes.py
+++ b/server/opds/routes.py
@@ -13,6 +13,7 @@ from .feeds import (
     _comic_entry_xml,
     _comic_media_type,
     _escape_xml,
+    _folder_entry_xml,
     _folder_href,
     _get_library_title,
     _now_iso,
@@ -25,6 +26,29 @@ from .feeds import (
 logger = get_logger(__name__)
 
 router = APIRouter()
+
+
+def _folder_preview_uuid(conn, folder_id: int) -> str | None:
+    """Return the newest comic cover available in a folder's full subtree."""
+    cur = conn.execute(
+        """
+        WITH RECURSIVE folder_tree(id) AS (
+            SELECT id FROM folders WHERE id = ?
+            UNION ALL
+            SELECT f.id
+            FROM folders f
+            INNER JOIN folder_tree ft ON f.parent_id = ft.id
+        )
+        SELECT c.uuid
+        FROM comics c
+        INNER JOIN folder_tree ft ON c.folder_id = ft.id
+        ORDER BY COALESCE(c.last_scanned_at, c.created_at) DESC, c.id DESC
+        LIMIT 1
+        """,
+        (folder_id,),
+    )
+    row = cur.fetchone()
+    return row["uuid"] if row else None
 
 
 @router.get("/favicon.ico", include_in_schema=False)
@@ -56,6 +80,10 @@ def opds_root(request: Request) -> Response:
             "SELECT id, name FROM folders WHERE parent_id IS NULL ORDER BY name"
         )
         folders = cur.fetchall()
+        folder_previews = {
+            folder["id"]: _folder_preview_uuid(conn, folder["id"])
+            for folder in folders
+        }
 
     updated = _now_iso()
     base_url = str(request.base_url)
@@ -65,15 +93,13 @@ def opds_root(request: Request) -> Response:
     entries = []
     for folder in folders:
         entries.append(
-            f"""
-  <entry>
-    <title>{_escape_xml(folder['name'])}</title>
-    <id>urn:folder:{folder['id']}</id>
-    <updated>{updated}</updated>
-    <link rel="subsection"
-          href="{_absolute_href(base_url, _folder_href(folder['id']))}"
-          type="application/atom+xml;profile=opds-catalog" />
-  </entry>"""
+            _folder_entry_xml(
+                folder["id"],
+                folder["name"],
+                updated,
+                base_url,
+                thumbnail_uuid=folder_previews[folder["id"]],
+            )
         )
 
     entries.append(
@@ -129,6 +155,10 @@ def opds_folder(folder_id: int, request: Request) -> Response:
             (folder_id,),
         )
         comics = cur.fetchall()
+        subfolder_previews = {
+            subfolder["id"]: _folder_preview_uuid(conn, subfolder["id"])
+            for subfolder in subfolders
+        }
 
     updated = _now_iso()
     base_url = str(request.base_url)
@@ -137,15 +167,13 @@ def opds_folder(folder_id: int, request: Request) -> Response:
     entries = []
     for sub in subfolders:
         entries.append(
-            f"""
-  <entry>
-    <title>{_escape_xml(sub['name'])}</title>
-    <id>urn:folder:{sub['id']}</id>
-    <updated>{updated}</updated>
-    <link rel="subsection"
-          href="{_absolute_href(base_url, _folder_href(sub['id']))}"
-          type="application/atom+xml;profile=opds-catalog" />
-  </entry>"""
+            _folder_entry_xml(
+                sub["id"],
+                sub["name"],
+                updated,
+                base_url,
+                thumbnail_uuid=subfolder_previews[sub["id"]],
+            )
         )
 
     is_series = len(subfolders) == 0

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -125,6 +125,18 @@ def test_opds_folder_entries_include_nested_comic_thumbnail(client, test_db):
         "type": "image/webp",
     }
 
+    recent_entry = next(
+        entry
+        for entry in ET.fromstring(root_response.content).findall('atom:entry', ns)
+        if entry.find('atom:id', ns).text == "urn:recent"
+    )
+    recent_thumbnail = recent_entry.find(
+        "atom:link[@rel='http://opds-spec.org/image/thumbnail']",
+        ns,
+    )
+    assert recent_thumbnail is not None
+    assert recent_thumbnail.attrib["href"] == expected_href
+
     folder_response = client.get(f"/opds/folder/{library_id}")
     folder_entry = ET.fromstring(folder_response.content).find('atom:entry', ns)
     folder_thumbnail = folder_entry.find(

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -80,6 +80,61 @@ def test_opds_root_has_required_elements(client):
     assert root.find('atom:updated', ns) is not None
 
 
+def test_opds_folder_entries_include_nested_comic_thumbnail(client, test_db):
+    """Navigation folders expose a representative cover from their subtree."""
+    with Session(test_db) as session:
+        library = Folder(name="Comics", path=".")
+        session.add(library)
+        session.commit()
+        session.refresh(library)
+
+        series = Folder(name="Example Series", path="Example Series", parent_id=library.id)
+        session.add(series)
+        session.commit()
+        session.refresh(series)
+        library_id = library.id
+
+        session.add(
+            Comic(
+                uuid="folder-preview-comic",
+                filename="Issue 1.cbz",
+                path="Example Series/Issue 1.cbz",
+                format="cbz",
+                file_size=100,
+                page_count=12,
+                file_modified_at=datetime.now(),
+                last_scanned_at=datetime.now(),
+                folder_id=series.id,
+            )
+        )
+        session.commit()
+
+    ns = {'atom': 'http://www.w3.org/2005/Atom'}
+    expected_href = "http://testserver/opds/comic/folder-preview-comic/thumbnail"
+
+    root_response = client.get("/opds/")
+    root_entry = ET.fromstring(root_response.content).find('atom:entry', ns)
+    root_thumbnail = root_entry.find(
+        "atom:link[@rel='http://opds-spec.org/image/thumbnail']",
+        ns,
+    )
+    assert root_thumbnail is not None
+    assert root_thumbnail.attrib == {
+        "rel": "http://opds-spec.org/image/thumbnail",
+        "href": expected_href,
+        "type": "image/webp",
+    }
+
+    folder_response = client.get(f"/opds/folder/{library_id}")
+    folder_entry = ET.fromstring(folder_response.content).find('atom:entry', ns)
+    folder_thumbnail = folder_entry.find(
+        "atom:link[@rel='http://opds-spec.org/image/thumbnail']",
+        ns,
+    )
+    assert folder_thumbnail is not None
+    assert folder_thumbnail.attrib["href"] == expected_href
+
+
 def test_opds_search_returns_results(client, test_db, test_config):
     """Test that OPDS search returns results for matching comics."""
     # Add a test comic to the database

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -17,8 +17,9 @@ from server.opds.feeds import _comic_media_type
 
 
 @pytest.fixture
-def test_config(tmp_path):
+def test_config(tmp_path, monkeypatch):
     """Create a test configuration."""
+    monkeypatch.setattr("server.config.DATA_DIR", tmp_path, raising=True)
     library_path = tmp_path / "comics"
     library_path.mkdir()
     
@@ -80,8 +81,12 @@ def test_opds_root_has_required_elements(client):
     assert root.find('atom:updated', ns) is not None
 
 
-def test_opds_folder_entries_include_nested_comic_thumbnail(client, test_db):
-    """Navigation folders expose a representative cover from their subtree."""
+def test_opds_folder_entries_include_nested_comic_thumbnail(
+    client,
+    test_config,
+    test_db,
+):
+    """Navigation folders use the newest successfully generated subtree cover."""
     with Session(test_db) as session:
         library = Folder(name="Comics", path=".")
         session.add(library)
@@ -94,20 +99,37 @@ def test_opds_folder_entries_include_nested_comic_thumbnail(client, test_db):
         session.refresh(series)
         library_id = library.id
 
+        valid_comic = Comic(
+            uuid="folder-preview-comic",
+            filename="Issue 1.cbz",
+            path="Example Series/Issue 1.cbz",
+            format="cbz",
+            file_size=100,
+            page_count=12,
+            file_modified_at=datetime(2026, 1, 1),
+            last_scanned_at=datetime(2026, 1, 1),
+            thumbnail_generated=True,
+            folder_id=series.id,
+        )
+        session.add(valid_comic)
         session.add(
             Comic(
-                uuid="folder-preview-comic",
-                filename="Issue 1.cbz",
-                path="Example Series/Issue 1.cbz",
+                uuid="missing-newer-thumbnail",
+                filename="Issue 2.cbz",
+                path="Example Series/Issue 2.cbz",
                 format="cbz",
                 file_size=100,
                 page_count=12,
-                file_modified_at=datetime.now(),
-                last_scanned_at=datetime.now(),
+                file_modified_at=datetime(2026, 2, 1),
+                last_scanned_at=datetime(2026, 2, 1),
+                thumbnail_generated=False,
                 folder_id=series.id,
             )
         )
         session.commit()
+
+    test_config.thumbnails_dir.mkdir()
+    (test_config.thumbnails_dir / "folder-preview-comic.webp").write_bytes(b"webp")
 
     ns = {'atom': 'http://www.w3.org/2005/Atom'}
     expected_href = "http://testserver/opds/comic/folder-preview-comic/thumbnail"
@@ -124,6 +146,7 @@ def test_opds_folder_entries_include_nested_comic_thumbnail(client, test_db):
         "href": expected_href,
         "type": "image/webp",
     }
+    assert client.get(root_thumbnail.attrib["href"]).status_code == 200
 
     recent_entry = next(
         entry
@@ -145,6 +168,59 @@ def test_opds_folder_entries_include_nested_comic_thumbnail(client, test_db):
     )
     assert folder_thumbnail is not None
     assert folder_thumbnail.attrib["href"] == expected_href
+
+
+def test_recent_preview_matches_first_entry_when_scan_times_are_tied(
+    client,
+    test_config,
+    test_db,
+):
+    """Recent artwork and feed use the same deterministic tie-breaker."""
+    tied_scan_time = datetime(2026, 3, 1)
+    with Session(test_db) as session:
+        library = Folder(name="Comics", path=".")
+        session.add(library)
+        session.commit()
+        session.refresh(library)
+
+        for index in (1, 2):
+            session.add(
+                Comic(
+                    uuid=f"recent-{index}",
+                    filename=f"Issue {index}.cbz",
+                    path=f"Issue {index}.cbz",
+                    format="cbz",
+                    file_size=100,
+                    page_count=12,
+                    file_modified_at=tied_scan_time,
+                    last_scanned_at=tied_scan_time,
+                    thumbnail_generated=True,
+                    folder_id=library.id,
+                )
+            )
+        session.commit()
+
+    test_config.thumbnails_dir.mkdir()
+    for index in (1, 2):
+        (test_config.thumbnails_dir / f"recent-{index}.webp").write_bytes(b"webp")
+
+    ns = {'atom': 'http://www.w3.org/2005/Atom'}
+    root = ET.fromstring(client.get("/opds/").content)
+    recent_navigation = next(
+        entry
+        for entry in root.findall('atom:entry', ns)
+        if entry.find('atom:id', ns).text == "urn:recent"
+    )
+    preview_href = recent_navigation.find(
+        "atom:link[@rel='http://opds-spec.org/image/thumbnail']",
+        ns,
+    ).attrib["href"]
+
+    recent_feed = ET.fromstring(client.get("/opds/recent").content)
+    first_recent_id = recent_feed.find('atom:entry/atom:id', ns).text
+
+    assert preview_href.endswith("/recent-2/thumbnail")
+    assert first_recent_id == "urn:comic:recent-2"
 
 
 def test_opds_search_returns_results(client, test_db, test_config):


### PR DESCRIPTION
## Summary

- add optional thumbnail artwork to OPDS navigation entries
- choose a stable representative cover from the newest comic in each folder's full subtree
- give the Recent navigation entry the newest comic's cover
- reuse the existing comic thumbnail endpoint, leaving empty folders unchanged

## Why

OPDS clients such as Panels otherwise render Issued's organized folder hierarchy with generic folder icons. Supplying artwork keeps the hierarchy intact while making remote browsing feel like a local cover-based library.

## Testing

- `pytest -q` — 69 passed
- tested with Panels on iPad against a nested 442-comic library
- verified all 146 emitted folder preview URLs returned HTTP 200
