### PR TITLE
feat: add customizable web library display options

### DIFF
--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -395,6 +395,14 @@ html[data-layout-width="full"] .layout-container {
   grid-template-columns: repeat(auto-fill, minmax(min(100%, var(--cover-min-width)), 1fr)) !important;
 }
 
+html[data-thumbnail-size="tiny"] .cover-grid {
+  --cover-min-width: 4.75rem;
+}
+
+html[data-thumbnail-size="extra-small"] .cover-grid {
+  --cover-min-width: 5.5rem;
+}
+
 html[data-thumbnail-size="small"] .cover-grid {
   --cover-min-width: 6.5rem;
 }
@@ -403,9 +411,25 @@ html[data-thumbnail-size="large"] .cover-grid {
   --cover-min-width: 10rem;
 }
 
+html[data-thumbnail-size="extra-large"] .cover-grid {
+  --cover-min-width: 12rem;
+}
+
+html[data-thumbnail-size="huge"] .cover-grid {
+  --cover-min-width: 14rem;
+}
+
 @media (min-width: 640px) {
   .cover-grid {
     --cover-min-width: 11rem;
+  }
+
+  html[data-thumbnail-size="tiny"] .cover-grid {
+    --cover-min-width: 5.5rem;
+  }
+
+  html[data-thumbnail-size="extra-small"] .cover-grid {
+    --cover-min-width: 7rem;
   }
 
   html[data-thumbnail-size="small"] .cover-grid {
@@ -414,6 +438,14 @@ html[data-thumbnail-size="large"] .cover-grid {
 
   html[data-thumbnail-size="large"] .cover-grid {
     --cover-min-width: 14rem;
+  }
+
+  html[data-thumbnail-size="extra-large"] .cover-grid {
+    --cover-min-width: 18rem;
+  }
+
+  html[data-thumbnail-size="huge"] .cover-grid {
+    --cover-min-width: 22rem;
   }
 }
 

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -413,8 +413,44 @@ html[data-thumbnail-size="large"] .cover-grid {
   }
 
   html[data-thumbnail-size="large"] .cover-grid {
-  --cover-min-width: 14rem;
+    --cover-min-width: 14rem;
   }
+}
+
+html[data-borderless="true"] .cover-grid {
+  gap: 0 !important;
+}
+
+html[data-borderless="true"] .comic-card,
+html[data-borderless="true"] .folder-card {
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  transform: none !important;
+}
+
+html[data-borderless="true"] .comic-card-details,
+html[data-borderless="true"] .folder-card-details {
+  display: none !important;
+}
+
+html[data-borderless="true"] .folder-preview-mosaic,
+html[data-borderless="true"] .folder-preview-images,
+html[data-borderless="true"] .folder-thumb {
+  border-radius: 0 !important;
+}
+
+html[data-borderless="true"] .folder-preview-images {
+  gap: 0 !important;
+  padding: 0 !important;
+}
+
+.display-switch[aria-checked="true"] {
+  background-color: #7c3aed;
+}
+
+.display-switch[aria-checked="true"] .display-switch-thumb {
+  transform: translateX(1.25rem);
 }
 
 .display-option[aria-pressed="true"] {

--- a/reader/static/css/style.css
+++ b/reader/static/css/style.css
@@ -384,6 +384,51 @@
   display: none;
 }
 
+/* --- Library display preferences --- */
+
+html[data-layout-width="full"] .layout-container {
+  max-width: none !important;
+}
+
+.cover-grid {
+  --cover-min-width: 8rem;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, var(--cover-min-width)), 1fr)) !important;
+}
+
+html[data-thumbnail-size="small"] .cover-grid {
+  --cover-min-width: 6.5rem;
+}
+
+html[data-thumbnail-size="large"] .cover-grid {
+  --cover-min-width: 10rem;
+}
+
+@media (min-width: 640px) {
+  .cover-grid {
+    --cover-min-width: 11rem;
+  }
+
+  html[data-thumbnail-size="small"] .cover-grid {
+    --cover-min-width: 8.5rem;
+  }
+
+  html[data-thumbnail-size="large"] .cover-grid {
+  --cover-min-width: 14rem;
+  }
+}
+
+.display-option[aria-pressed="true"] {
+  border-color: #a78bfa;
+  background-color: #ede9fe;
+  color: #6d28d9;
+}
+
+html[data-theme="dark"] .display-option[aria-pressed="true"] {
+  border-color: #7c3aed !important;
+  background-color: #2e1065 !important;
+  color: #ddd6fe !important;
+}
+
 /* --- Color theme --- */
 html[data-theme="dark"] {
   color-scheme: dark;

--- a/reader/static/js/layout.js
+++ b/reader/static/js/layout.js
@@ -3,7 +3,16 @@
   const sizeStorageKey = 'issued-thumbnail-size';
   const borderlessStorageKey = 'issued-borderless-collage';
   const validWidths = ['fixed', 'full'];
-  const validSizes = ['small', 'medium', 'large'];
+  const validSizes = ['tiny', 'extra-small', 'small', 'medium', 'large', 'extra-large', 'huge'];
+  const sizeLabels = {
+    tiny: 'Tiny',
+    'extra-small': 'Extra small',
+    small: 'Small',
+    medium: 'Medium',
+    large: 'Large',
+    'extra-large': 'Extra large',
+    huge: 'Huge',
+  };
   const root = document.documentElement;
   const toggle = document.getElementById('display-settings-toggle');
   const panel = document.getElementById('display-settings-panel');
@@ -31,7 +40,7 @@
     const normalizedSize = validSizes.includes(size) ? size : 'medium';
     const sizeIndex = validSizes.indexOf(normalizedSize);
     root.dataset.thumbnailSize = normalizedSize;
-    if (sizeLabel) sizeLabel.textContent = normalizedSize[0].toUpperCase() + normalizedSize.slice(1);
+    if (sizeLabel) sizeLabel.textContent = sizeLabels[normalizedSize];
     if (decreaseButton) decreaseButton.disabled = sizeIndex === 0;
     if (increaseButton) increaseButton.disabled = sizeIndex === validSizes.length - 1;
     if (shouldPersist) persist(sizeStorageKey, normalizedSize);

--- a/reader/static/js/layout.js
+++ b/reader/static/js/layout.js
@@ -1,6 +1,7 @@
 (() => {
   const widthStorageKey = 'issued-layout-width';
   const sizeStorageKey = 'issued-thumbnail-size';
+  const borderlessStorageKey = 'issued-borderless-collage';
   const validWidths = ['fixed', 'full'];
   const validSizes = ['small', 'medium', 'large'];
   const root = document.documentElement;
@@ -9,6 +10,7 @@
   const sizeLabel = document.getElementById('thumbnail-size-label');
   const decreaseButton = document.getElementById('thumbnail-size-decrease');
   const increaseButton = document.getElementById('thumbnail-size-increase');
+  const borderlessToggle = document.getElementById('borderless-collage-toggle');
 
   const persist = (key, value) => {
     try {
@@ -35,8 +37,16 @@
     if (shouldPersist) persist(sizeStorageKey, normalizedSize);
   };
 
+  const applyBorderless = (enabled, shouldPersist = false) => {
+    const isEnabled = enabled === true || enabled === 'true';
+    root.dataset.borderless = String(isEnabled);
+    borderlessToggle?.setAttribute('aria-checked', String(isEnabled));
+    if (shouldPersist) persist(borderlessStorageKey, String(isEnabled));
+  };
+
   applyWidth(root.dataset.layoutWidth);
   applySize(root.dataset.thumbnailSize);
+  applyBorderless(root.dataset.borderless);
 
   if (!toggle || !panel) return;
 
@@ -63,6 +73,10 @@
   increaseButton?.addEventListener('click', () => {
     const currentIndex = validSizes.indexOf(root.dataset.thumbnailSize);
     applySize(validSizes[Math.min(validSizes.length - 1, currentIndex + 1)], true);
+  });
+
+  borderlessToggle?.addEventListener('click', () => {
+    applyBorderless(root.dataset.borderless !== 'true', true);
   });
 
   document.addEventListener('click', (event) => {

--- a/reader/static/js/layout.js
+++ b/reader/static/js/layout.js
@@ -1,0 +1,78 @@
+(() => {
+  const widthStorageKey = 'issued-layout-width';
+  const sizeStorageKey = 'issued-thumbnail-size';
+  const validWidths = ['fixed', 'full'];
+  const validSizes = ['small', 'medium', 'large'];
+  const root = document.documentElement;
+  const toggle = document.getElementById('display-settings-toggle');
+  const panel = document.getElementById('display-settings-panel');
+  const sizeLabel = document.getElementById('thumbnail-size-label');
+  const decreaseButton = document.getElementById('thumbnail-size-decrease');
+  const increaseButton = document.getElementById('thumbnail-size-increase');
+
+  const persist = (key, value) => {
+    try {
+      localStorage.setItem(key, value);
+    } catch (_) {}
+  };
+
+  const applyWidth = (width, shouldPersist = false) => {
+    const normalizedWidth = validWidths.includes(width) ? width : 'fixed';
+    root.dataset.layoutWidth = normalizedWidth;
+    document.querySelectorAll('[data-layout-width]').forEach((button) => {
+      button.setAttribute('aria-pressed', String(button.dataset.layoutWidth === normalizedWidth));
+    });
+    if (shouldPersist) persist(widthStorageKey, normalizedWidth);
+  };
+
+  const applySize = (size, shouldPersist = false) => {
+    const normalizedSize = validSizes.includes(size) ? size : 'medium';
+    const sizeIndex = validSizes.indexOf(normalizedSize);
+    root.dataset.thumbnailSize = normalizedSize;
+    if (sizeLabel) sizeLabel.textContent = normalizedSize[0].toUpperCase() + normalizedSize.slice(1);
+    if (decreaseButton) decreaseButton.disabled = sizeIndex === 0;
+    if (increaseButton) increaseButton.disabled = sizeIndex === validSizes.length - 1;
+    if (shouldPersist) persist(sizeStorageKey, normalizedSize);
+  };
+
+  applyWidth(root.dataset.layoutWidth);
+  applySize(root.dataset.thumbnailSize);
+
+  if (!toggle || !panel) return;
+
+  const closePanel = () => {
+    panel.classList.add('hidden');
+    toggle.setAttribute('aria-expanded', 'false');
+  };
+
+  toggle.addEventListener('click', () => {
+    const shouldOpen = panel.classList.contains('hidden');
+    panel.classList.toggle('hidden', !shouldOpen);
+    toggle.setAttribute('aria-expanded', String(shouldOpen));
+  });
+
+  document.querySelectorAll('[data-layout-width]').forEach((button) => {
+    button.addEventListener('click', () => applyWidth(button.dataset.layoutWidth, true));
+  });
+
+  decreaseButton?.addEventListener('click', () => {
+    const currentIndex = validSizes.indexOf(root.dataset.thumbnailSize);
+    applySize(validSizes[Math.max(0, currentIndex - 1)], true);
+  });
+
+  increaseButton?.addEventListener('click', () => {
+    const currentIndex = validSizes.indexOf(root.dataset.thumbnailSize);
+    applySize(validSizes[Math.min(validSizes.length - 1, currentIndex + 1)], true);
+  });
+
+  document.addEventListener('click', (event) => {
+    if (!panel.contains(event.target) && !toggle.contains(event.target)) closePanel();
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closePanel();
+      toggle.focus();
+    }
+  });
+})();

--- a/reader/templates/base.html
+++ b/reader/templates/base.html
@@ -10,12 +10,22 @@
   <title>{% block title %}Comic Library{% endblock %}</title>
   <script>
     (() => {
+      const root = document.documentElement;
       try {
         const savedTheme = localStorage.getItem('issued-theme');
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        document.documentElement.dataset.theme = savedTheme || (prefersDark ? 'dark' : 'light');
+        const savedLayoutWidth = localStorage.getItem('issued-layout-width');
+        const savedThumbnailSize = localStorage.getItem('issued-thumbnail-size');
+
+        root.dataset.theme = savedTheme || (prefersDark ? 'dark' : 'light');
+        root.dataset.layoutWidth = ['fixed', 'full'].includes(savedLayoutWidth) ? savedLayoutWidth : 'fixed';
+        root.dataset.thumbnailSize = ['small', 'medium', 'large'].includes(savedThumbnailSize)
+          ? savedThumbnailSize
+          : 'medium';
       } catch (_) {
-        document.documentElement.dataset.theme = 'light';
+        root.dataset.theme = 'light';
+        root.dataset.layoutWidth = 'fixed';
+        root.dataset.thumbnailSize = 'medium';
       }
     })();
   </script>
@@ -31,7 +41,7 @@
 <body
   class="min-h-screen bg-gradient-to-br from-violet-50 via-white to-purple-50 text-gray-900 antialiased pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)]">
   <header class="border-b border-violet-100 bg-white/80 py-3 sm:py-4 backdrop-blur-md shadow-sm">
-    <div class="mx-auto max-w-6xl px-3 sm:px-4">
+    <div class="layout-container mx-auto max-w-6xl px-3 sm:px-4">
       <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:gap-4">
         <div class="flex shrink-0 justify-center lg:justify-start lg:w-[min(14rem,28%)]">
           <a href="{{ url_path(request, 'browse_root') }}"
@@ -102,10 +112,11 @@
       {% endif %}
     </div>
   </header>
-  <main class="mx-auto max-w-6xl px-3 py-4 sm:px-4 sm:py-6">
+  <main class="layout-container mx-auto max-w-6xl px-3 py-4 sm:px-4 sm:py-6">
     {% block content %}{% endblock %}
   </main>
   {% block scripts %}{% endblock %}
+  <script src="{{ url_path(request, 'reader_static', path='/js/layout.js') }}"></script>
   <script src="{{ url_path(request, 'reader_static', path='/js/theme.js') }}"></script>
   <script>lucide.createIcons();</script>
 </body>

--- a/reader/templates/base.html
+++ b/reader/templates/base.html
@@ -20,7 +20,9 @@
 
         root.dataset.theme = savedTheme || (prefersDark ? 'dark' : 'light');
         root.dataset.layoutWidth = ['fixed', 'full'].includes(savedLayoutWidth) ? savedLayoutWidth : 'fixed';
-        root.dataset.thumbnailSize = ['small', 'medium', 'large'].includes(savedThumbnailSize)
+        root.dataset.thumbnailSize = [
+          'tiny', 'extra-small', 'small', 'medium', 'large', 'extra-large', 'huge'
+        ].includes(savedThumbnailSize)
           ? savedThumbnailSize
           : 'medium';
         root.dataset.borderless = savedBorderless === 'true' ? 'true' : 'false';

--- a/reader/templates/base.html
+++ b/reader/templates/base.html
@@ -16,16 +16,19 @@
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         const savedLayoutWidth = localStorage.getItem('issued-layout-width');
         const savedThumbnailSize = localStorage.getItem('issued-thumbnail-size');
+        const savedBorderless = localStorage.getItem('issued-borderless-collage');
 
         root.dataset.theme = savedTheme || (prefersDark ? 'dark' : 'light');
         root.dataset.layoutWidth = ['fixed', 'full'].includes(savedLayoutWidth) ? savedLayoutWidth : 'fixed';
         root.dataset.thumbnailSize = ['small', 'medium', 'large'].includes(savedThumbnailSize)
           ? savedThumbnailSize
           : 'medium';
+        root.dataset.borderless = savedBorderless === 'true' ? 'true' : 'false';
       } catch (_) {
         root.dataset.theme = 'light';
         root.dataset.layoutWidth = 'fixed';
         root.dataset.thumbnailSize = 'medium';
+        root.dataset.borderless = 'false';
       }
     })();
   </script>

--- a/reader/templates/browser.html
+++ b/reader/templates/browser.html
@@ -38,7 +38,7 @@
               class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-gray-200 text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
               aria-label="Use smaller covers"><i data-lucide="minus" class="h-4 w-4"></i></button>
             <span id="thumbnail-size-label"
-              class="min-w-16 text-center text-sm font-medium text-gray-700">Medium</span>
+              class="min-w-20 text-center text-sm font-medium text-gray-700">Medium</span>
             <button id="thumbnail-size-increase" type="button"
               class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-gray-200 text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
               aria-label="Use larger covers"><i data-lucide="plus" class="h-4 w-4"></i></button>

--- a/reader/templates/browser.html
+++ b/reader/templates/browser.html
@@ -44,6 +44,18 @@
               aria-label="Use larger covers"><i data-lucide="plus" class="h-4 w-4"></i></button>
           </div>
         </div>
+
+        <div class="mt-4 flex items-center justify-between gap-4 border-t border-gray-200 pt-4">
+          <div>
+            <p class="text-sm font-medium text-gray-900">Borderless collage</p>
+            <p class="mt-0.5 text-xs leading-snug text-gray-500">Show a seamless wall of cover art.</p>
+          </div>
+          <button id="borderless-collage-toggle" type="button" role="switch" aria-checked="false"
+            class="display-switch relative h-7 w-12 shrink-0 rounded-full bg-gray-200 transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+            aria-label="Toggle borderless collage">
+            <span class="display-switch-thumb absolute left-1 top-1 h-5 w-5 rounded-full bg-white shadow transition-transform"></span>
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/reader/templates/browser.html
+++ b/reader/templates/browser.html
@@ -4,9 +4,49 @@
 
 {% block content %}
 <div class="browser fade-in">
-  <h1
-    class="mb-4 bg-gradient-to-r from-violet-600 via-purple-600 to-pink-600 bg-clip-text text-2xl font-bold text-transparent sm:mb-6 sm:text-3xl">
-    {{ title }}</h1>
+  <div class="mb-4 flex items-center justify-between gap-3 sm:mb-6">
+    <h1
+      class="bg-gradient-to-r from-violet-600 via-purple-600 to-pink-600 bg-clip-text text-2xl font-bold text-transparent sm:text-3xl">
+      {{ title }}</h1>
+
+    <div class="relative shrink-0">
+      <button id="display-settings-toggle" type="button"
+        class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-purple-500"
+        aria-expanded="false" aria-controls="display-settings-panel">
+        <i data-lucide="sliders-horizontal" class="h-4 w-4"></i>
+        <span class="hidden sm:inline">Display</span>
+      </button>
+
+      <div id="display-settings-panel"
+        class="absolute right-0 top-12 z-50 hidden w-72 rounded-xl border border-gray-200 bg-white p-4 shadow-xl">
+        <div>
+          <p class="mb-2 text-sm font-medium text-gray-900">Page width</p>
+          <div class="grid grid-cols-2 gap-2" role="group" aria-label="Page width">
+            <button type="button"
+              class="display-option rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+              data-layout-width="fixed" aria-pressed="true">Fixed</button>
+            <button type="button"
+              class="display-option rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+              data-layout-width="full" aria-pressed="false">Full width</button>
+          </div>
+        </div>
+
+        <div class="mt-4 border-t border-gray-200 pt-4">
+          <p class="mb-2 text-sm font-medium text-gray-900">Cover size</p>
+          <div class="flex items-center justify-between gap-3">
+            <button id="thumbnail-size-decrease" type="button"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-gray-200 text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
+              aria-label="Use smaller covers"><i data-lucide="minus" class="h-4 w-4"></i></button>
+            <span id="thumbnail-size-label"
+              class="min-w-16 text-center text-sm font-medium text-gray-700">Medium</span>
+            <button id="thumbnail-size-increase" type="button"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-gray-200 text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40"
+              aria-label="Use larger covers"><i data-lucide="plus" class="h-4 w-4"></i></button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 
   {% if folder_id is defined and folder_id and is_leaf %}
   <div class="mb-4 flex flex-wrap items-center gap-2">

--- a/reader/templates/partials/comics-section.html
+++ b/reader/templates/partials/comics-section.html
@@ -134,7 +134,7 @@
         group.comics|length }}</span>
     </h3>
     <!-- Grid view -->
-    <ul class="comics-grid-list grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+    <ul class="comics-grid-list cover-grid grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
       {% for c in group.comics %}
       <li class="group relative">
         <div
@@ -181,7 +181,7 @@
   {% endfor %}
   {% else %}
   <!-- Grid view -->
-  <ul class="comics-grid-list grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+  <ul class="comics-grid-list cover-grid grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
     {% for c in comics %}
     <li class="group relative">
       <div

--- a/reader/templates/partials/comics-section.html
+++ b/reader/templates/partials/comics-section.html
@@ -163,7 +163,8 @@
                 class="rounded-xl bg-violet-600 px-5 py-2.5 text-sm font-bold text-white shadow-lg pointer-events-auto">Read</span>
             </a>
           </div>
-          <a href="{{ url_path(request, 'reader_view', comic_uuid=c.uuid) }}" class="block bg-white p-3">
+          <a href="{{ url_path(request, 'reader_view', comic_uuid=c.uuid) }}"
+            class="comic-card-details block bg-white p-3">
             <span class="line-clamp-2 block text-center text-sm font-medium text-gray-800">{{ c.filename }}</span>
             {% if c.get('page_count') and c.page_count > 0 %}
             <span class="mt-1 block text-center text-xs text-gray-500">{{ c.page_count }} pages</span>
@@ -210,7 +211,8 @@
               class="rounded-xl bg-violet-600 px-5 py-2.5 text-sm font-bold text-white shadow-lg pointer-events-auto">Read</span>
           </a>
         </div>
-        <a href="{{ url_path(request, 'reader_view', comic_uuid=c.uuid) }}" class="block bg-white p-3">
+        <a href="{{ url_path(request, 'reader_view', comic_uuid=c.uuid) }}"
+          class="comic-card-details block bg-white p-3">
           <span class="line-clamp-2 block text-center text-sm font-medium text-gray-800">{{ c.filename }}</span>
           {% if c.get('page_count') and c.page_count > 0 %}
           <span class="mt-1 block text-center text-xs text-gray-500">{{ c.page_count }} pages</span>

--- a/reader/templates/partials/folder-grid.html
+++ b/reader/templates/partials/folder-grid.html
@@ -1,7 +1,7 @@
 {% if folders %}
 <section class="mb-8">
   <h2 class="mb-4 text-lg font-bold text-gray-800">Folders</h2>
-  <ul class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+<ul class="cover-grid grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
     {% for f in folders %}
     <li class="flex">
       <a href="{{ url_path(request, 'browse_folder', folder_id=f.id) }}"

--- a/reader/templates/partials/folder-grid.html
+++ b/reader/templates/partials/folder-grid.html
@@ -5,7 +5,7 @@
     {% for f in folders %}
     <li class="flex">
       <a href="{{ url_path(request, 'browse_folder', folder_id=f.id) }}"
-        class="group flex h-full w-full flex-col overflow-hidden rounded-2xl border border-violet-100 bg-white shadow-md transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+        class="folder-card group flex h-full w-full flex-col overflow-hidden rounded-2xl border border-violet-100 bg-white shadow-md transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
         data-folder-id="{{ f.id }}">
         <div
           class="folder-preview-mosaic relative aspect-[2/3] w-full overflow-hidden bg-gradient-to-br from-violet-50 to-purple-50">
@@ -19,7 +19,7 @@
             <div class="folder-thumb folder-thumb-4 rounded"></div>
           </div>
         </div>
-        <div class="flex min-h-11 flex-col items-center justify-center p-4">
+        <div class="folder-card-details flex min-h-11 flex-col items-center justify-center p-4">
           <span class="line-clamp-2 text-center text-sm font-semibold text-gray-800 leading-snug">{{ f.name }}</span>
           <span class="mt-1.5 shrink-0 text-center text-xs font-medium text-violet-600">{{ f.get('item_count', 0) }}
             items</span>

--- a/tests/test_reader_layout.py
+++ b/tests/test_reader_layout.py
@@ -11,7 +11,9 @@ def test_layout_preferences_are_persisted_and_validated():
     assert "issued-thumbnail-size" in script
     assert "issued-borderless-collage" in script
     assert "['fixed', 'full']" in script
-    assert "['small', 'medium', 'large']" in script
+    assert "['tiny', 'extra-small', 'small', 'medium', 'large', 'extra-large', 'huge']" in script
+    assert "Extra small" in script
+    assert "Extra large" in script
     assert "localStorage.setItem" in script
     assert "aria-pressed" in script
     assert "aria-checked" in script
@@ -23,6 +25,10 @@ def test_layout_styles_support_full_width_and_resizable_cover_grids():
     assert 'html[data-layout-width="full"] .layout-container' in styles
     assert 'html[data-thumbnail-size="small"] .cover-grid' in styles
     assert 'html[data-thumbnail-size="large"] .cover-grid' in styles
+    assert 'html[data-thumbnail-size="tiny"] .cover-grid' in styles
+    assert 'html[data-thumbnail-size="extra-small"] .cover-grid' in styles
+    assert 'html[data-thumbnail-size="extra-large"] .cover-grid' in styles
+    assert 'html[data-thumbnail-size="huge"] .cover-grid' in styles
     assert 'html[data-borderless="true"] .cover-grid' in styles
     assert 'html[data-borderless="true"] .comic-card-details' in styles
     assert 'html[data-borderless="true"] .folder-card-details' in styles

--- a/tests/test_reader_layout.py
+++ b/tests/test_reader_layout.py
@@ -9,10 +9,12 @@ def test_layout_preferences_are_persisted_and_validated():
 
     assert "issued-layout-width" in script
     assert "issued-thumbnail-size" in script
+    assert "issued-borderless-collage" in script
     assert "['fixed', 'full']" in script
     assert "['small', 'medium', 'large']" in script
     assert "localStorage.setItem" in script
     assert "aria-pressed" in script
+    assert "aria-checked" in script
 
 
 def test_layout_styles_support_full_width_and_resizable_cover_grids():
@@ -21,6 +23,9 @@ def test_layout_styles_support_full_width_and_resizable_cover_grids():
     assert 'html[data-layout-width="full"] .layout-container' in styles
     assert 'html[data-thumbnail-size="small"] .cover-grid' in styles
     assert 'html[data-thumbnail-size="large"] .cover-grid' in styles
+    assert 'html[data-borderless="true"] .cover-grid' in styles
+    assert 'html[data-borderless="true"] .comic-card-details' in styles
+    assert 'html[data-borderless="true"] .folder-card-details' in styles
     assert "--cover-min-width" in styles
 
 

--- a/tests/test_reader_layout.py
+++ b/tests/test_reader_layout.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_layout_preferences_are_persisted_and_validated():
+    script = (PROJECT_ROOT / "reader" / "static" / "js" / "layout.js").read_text()
+
+    assert "issued-layout-width" in script
+    assert "issued-thumbnail-size" in script
+    assert "['fixed', 'full']" in script
+    assert "['small', 'medium', 'large']" in script
+    assert "localStorage.setItem" in script
+    assert "aria-pressed" in script
+
+
+def test_layout_styles_support_full_width_and_resizable_cover_grids():
+    styles = (PROJECT_ROOT / "reader" / "static" / "css" / "style.css").read_text()
+
+    assert 'html[data-layout-width="full"] .layout-container' in styles
+    assert 'html[data-thumbnail-size="small"] .cover-grid' in styles
+    assert 'html[data-thumbnail-size="large"] .cover-grid' in styles
+    assert "--cover-min-width" in styles
+
+
+def test_library_grids_opt_in_to_cover_sizing():
+    folder_grid = (PROJECT_ROOT / "reader" / "templates" / "partials" / "folder-grid.html").read_text()
+    comics_section = (PROJECT_ROOT / "reader" / "templates" / "partials" / "comics-section.html").read_text()
+
+    assert "cover-grid" in folder_grid
+    assert comics_section.count("cover-grid") == 2

--- a/tests/test_reader_scan_action.py
+++ b/tests/test_reader_scan_action.py
@@ -86,6 +86,11 @@ def test_reader_root_renders_scan_button(tmp_path, monkeypatch):
     assert 'id="theme-toggle"' in response.text
     assert 'aria-label="Switch to dark mode"' in response.text
     assert '/reader/static/js/theme.js' in response.text
+    assert 'id="display-settings-toggle"' in response.text
+    assert 'id="display-settings-panel"' in response.text
+    assert 'id="thumbnail-size-decrease"' in response.text
+    assert 'id="thumbnail-size-increase"' in response.text
+    assert '/reader/static/js/layout.js' in response.text
 
 
 def test_reader_recent_renders_scan_button(tmp_path, monkeypatch):

--- a/tests/test_reader_scan_action.py
+++ b/tests/test_reader_scan_action.py
@@ -90,6 +90,7 @@ def test_reader_root_renders_scan_button(tmp_path, monkeypatch):
     assert 'id="display-settings-panel"' in response.text
     assert 'id="thumbnail-size-decrease"' in response.text
     assert 'id="thumbnail-size-increase"' in response.text
+    assert 'id="borderless-collage-toggle"' in response.text
     assert '/reader/static/js/layout.js' in response.text
 
 


### PR DESCRIPTION
## Summary

- add persisted fixed and full-width layouts to the web reader
- add a responsive seven-step cover-size scale from Tiny through Huge
- add a borderless collage mode that removes gaps, framing, rounded corners, and cover labels
- apply saved preferences before rendering to avoid layout flashes
- preserve the existing fixed-width, medium-cover presentation as the default

## Testing

- `uv run --with-requirements requirements.txt pytest -q`
- 71 tests passed